### PR TITLE
Caching fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     with:
       ruby-version: ${{ inputs.ruby-version }}
       bundler-cache: true
-      cache-version: ${{ inputs.rails-version }}-${{ inputs.solidus-branch }}
+      cache-version: ${{ inputs.rails-version }}-${{ inputs.solidus-branch }}-{{ inputs.database }}-{{ inputs.ruby-version }}
       rubygems: "latest"
   - name: Restore apt cache
     id: apt-cache


### PR DESCRIPTION
We were getting a lot of warnings because the bundler cache is "already present". This likely has to do with the fact that prior to this commit, not all inputs were present in the cache key for the bundler cache.